### PR TITLE
Support Google translations by using glossary

### DIFF
--- a/easy_translate.gemspec
+++ b/easy_translate.gemspec
@@ -3,6 +3,7 @@ require File.expand_path('lib/easy_translate/version', File.dirname(__FILE__))
 spec = Gem::Specification.new do |s|
   s.name = 'easy_translate'
   s.author = 'John Crepezzi'
+  s.add_dependency('google-cloud-translate-v3')
   s.add_development_dependency('rspec')
   s.add_dependency 'thread'
   s.add_dependency 'thread_safe'


### PR DESCRIPTION
References https://github.com/denkungsart/prestage/issues/16223

__Todo:__
- [x] fix `require` google sdk statement (throws loading error)

Changes
- translate with using glossary when ENV variable `GOOGLE_GLOSSARY_ID` is defined